### PR TITLE
Remove runner_provisioning_timeout from auto-retry reasons

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,6 @@ stages:
       - api_failure
       - data_integrity_failure
       - job_execution_timeout
-      - runner_provisioning_timeout
       - runner_system_failure
       - scheduler_failure
       - stuck_or_timeout_failure


### PR DESCRIPTION
This value was part of an unfinished feature that got removed due to capacity reasons. It should also never have been specified in the retry config because GitLab would had automatically retried the job internally.