### PR TITLE
The INITIAL_ROOT_PASSWORD within the .env file does not follow our security standard

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -6,7 +6,7 @@ SSL_ENABLED=false
 SSL_CERT_FILE= # must be located in ./certs, defaults to "<hostname>.pem"
 SSL_KEY_FILE= # must be located in ./certs, defaults to "<hostname>.key"
 
-INITIAL_ROOT_PASSWORD=BWjDE=hA_m95
+INITIAL_ROOT_PASSWORD=BWjDE-hA_m95
 INITIAL_ROOT_MAIL=root@code0.tech
 
 # Runtime config

--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -6,7 +6,7 @@ SSL_ENABLED=false
 SSL_CERT_FILE= # must be located in ./certs, defaults to "<hostname>.pem"
 SSL_KEY_FILE= # must be located in ./certs, defaults to "<hostname>.key"
 
-INITIAL_ROOT_PASSWORD=root
+INITIAL_ROOT_PASSWORD=BWjDE=hA_m95
 INITIAL_ROOT_MAIL=root@code0.tech
 
 # Runtime config


### PR DESCRIPTION
Close #572 